### PR TITLE
Refine signalhandler

### DIFF
--- a/src/BusConnection.cc
+++ b/src/BusConnection.cc
@@ -243,18 +243,17 @@ NAN_METHOD(BusConnection::RegisterSignalHandler) {
     return NanThrowError("RegisterSignalHandler requires a receiver BusObject, signalHandler callback, interface, interface member name, and (optional) srcPath.");
 
   BusConnection* connection = node::ObjectWrap::Unwrap<BusConnection>(args.This());
-  BusObjectWrapper* wrapper = node::ObjectWrap::Unwrap<BusObjectWrapper>(args[0].As<v8::Object>());
   InterfaceWrapper* interface = node::ObjectWrap::Unwrap<InterfaceWrapper>(args[2].As<v8::Object>());
   const ajn::InterfaceDescription::Member* signalMember = interface->interface->GetMember(*NanUtf8String(args[3]));
 
   v8::Local<v8::Function> fn = args[1].As<v8::Function>();
   NanCallback *callback = new NanCallback(fn);
-  wrapper->object->SetSignalCallback(callback);
+  SignalHandlerImpl* signalHandler = new SignalHandlerImpl(callback);
   QStatus status = ER_OK;
   if(args.Length() == 5){
-    status = connection->bus->RegisterSignalHandler(wrapper->object, static_cast<ajn::MessageReceiver::SignalHandler>(&BusObjectImpl::ReceiveSignal), signalMember, strdup(*NanUtf8String(args[4])));
+    status = connection->bus->RegisterSignalHandler(signalHandler, static_cast<ajn::MessageReceiver::SignalHandler>(&SignalHandlerImpl::Signal), signalMember, strdup(*NanUtf8String(args[4])));
   }else{
-    status = connection->bus->RegisterSignalHandler(wrapper->object, static_cast<ajn::MessageReceiver::SignalHandler>(&BusObjectImpl::ReceiveSignal), signalMember, NULL);
+    status = connection->bus->RegisterSignalHandler(signalHandler, static_cast<ajn::MessageReceiver::SignalHandler>(&SignalHandlerImpl::Signal), signalMember, NULL);
   }
 
   NanReturnValue(NanNew<v8::Integer>(static_cast<int>(status)));

--- a/src/BusObjectWrapper.cc
+++ b/src/BusObjectWrapper.cc
@@ -96,9 +96,6 @@ NAN_METHOD(BusObjectWrapper::Signal) {
 }
 
 BusObjectImpl::BusObjectImpl(const char* path):ajn::BusObject(path){
-  loop = uv_default_loop();
-  signalCallback.callback = NULL;
-  uv_async_init(loop, &signal_async, signal_callback);
 }
 
 QStatus BusObjectImpl::AddInter(ajn::InterfaceDescription* interface){
@@ -106,52 +103,4 @@ QStatus BusObjectImpl::AddInter(ajn::InterfaceDescription* interface){
 }
 
 BusObjectImpl::~BusObjectImpl(){
-  if(signalCallback.callback){
-    delete signalCallback.callback;
-  }
 }
-
-void BusObjectImpl::signal_callback(uv_async_t *handle, int status) {
-    CallbackHolder* holder = (CallbackHolder*) handle->data;
-
-    v8::Local<v8::Object> msg = v8::Object::New();
-    size_t msgIndex = 0;
-    const ajn::MsgArg* arg = (*holder->message)->GetArg(msgIndex);
-    while(arg != NULL){
-      msgArgToObject(arg, msgIndex, msg);
-      msgIndex++;
-      arg = (*holder->message)->GetArg(msgIndex);
-    }
-
-    v8::Local<v8::Object> sender = v8::Object::New();
-    sender->Set(NanNew<v8::String>("sender"), NanNew<v8::String>((*holder->message)->GetSender()));
-    sender->Set(NanNew<v8::String>("session_id"), NanNew<v8::Integer>((*holder->message)->GetSessionId()));
-    sender->Set(NanNew<v8::String>("timestamp"), NanNew<v8::Integer>((*holder->message)->GetTimeStamp()));
-    sender->Set(NanNew<v8::String>("member_name"), NanNew<v8::String>((*holder->message)->GetMemberName()));
-    sender->Set(NanNew<v8::String>("object_path"), NanNew<v8::String>((*holder->message)->GetObjectPath()));
-    sender->Set(NanNew<v8::String>("signature"), NanNew<v8::String>((*holder->message)->GetSignature()));
-
-    v8::Handle<v8::Value> argv[] = {
-      msg,
-      sender
-    };
-    holder->callback->Call(2, argv);
-
-    if(holder->message){
-      delete holder->message;
-      holder->message = NULL;
-    }
-}
-
-void BusObjectImpl::ReceiveSignal(const ajn::InterfaceDescription::Member *member, const char *srcPath, ajn::Message &message){
-  if(signalCallback.callback){
-    signal_async.data = (void*) &signalCallback;
-    signalCallback.message = new ajn::Message(message);
-    uv_async_send(&signal_async);
-  }
-}
-
-void BusObjectImpl::SetSignalCallback(NanCallback* callback){
-  signalCallback.callback = callback;
-}
-

--- a/src/BusObjectWrapper.h
+++ b/src/BusObjectWrapper.h
@@ -9,9 +9,9 @@ NAN_METHOD(BusObjectConstructor);
 
 class BusObjectImpl : public ajn::BusObject{
 public:
-	BusObjectImpl(const char* path);
+    BusObjectImpl(const char* path);
     ~BusObjectImpl();
-	QStatus AddInter(ajn::InterfaceDescription* interface);
+    QStatus AddInter(ajn::InterfaceDescription* interface);
 };
 
 class BusObjectWrapper : public node::ObjectWrap {

--- a/src/BusObjectWrapper.h
+++ b/src/BusObjectWrapper.h
@@ -8,21 +8,10 @@
 NAN_METHOD(BusObjectConstructor);
 
 class BusObjectImpl : public ajn::BusObject{
-    uv_loop_t *loop;
-    uv_async_t signal_async;
-
-    struct CallbackHolder{
-      NanCallback* callback;
-      ajn::Message *message;
-    } signalCallback;
-
-	public:
-		BusObjectImpl(const char* path);
+public:
+	BusObjectImpl(const char* path);
     ~BusObjectImpl();
-    static void signal_callback(uv_async_t *handle, int status);
-	  QStatus AddInter(ajn::InterfaceDescription* interface);
-    void ReceiveSignal(const ajn::InterfaceDescription::Member *member, const char *srcPath, ajn::Message &message);
-    void SetSignalCallback(NanCallback* callback);
+	QStatus AddInter(ajn::InterfaceDescription* interface);
 };
 
 class BusObjectWrapper : public node::ObjectWrap {

--- a/src/SignalHandlerImpl.cc
+++ b/src/SignalHandlerImpl.cc
@@ -1,5 +1,6 @@
 #include "nan.h"
 
+#include "util.h"
 #include "SignalHandlerImpl.h"
 #include <Message.h>
 #include <alljoyn/InterfaceDescription.h>
@@ -17,18 +18,37 @@ SignalHandlerImpl::~SignalHandlerImpl(){
 void SignalHandlerImpl::signal_callback(uv_async_t *handle, int status) {
     CallbackHolder* holder = (CallbackHolder*) handle->data;
 
+    v8::Local<v8::Object> msg = v8::Object::New();
+    size_t msgIndex = 0;
+    const ajn::MsgArg* arg = (*holder->message)->GetArg(msgIndex);
+    while(arg != NULL){
+      msgArgToObject(arg, msgIndex, msg);
+      msgIndex++;
+      arg = (*holder->message)->GetArg(msgIndex);
+    }
+
+    v8::Local<v8::Object> sender = v8::Object::New();
+    sender->Set(NanNew<v8::String>("sender"), NanNew<v8::String>((*holder->message)->GetSender()));
+    sender->Set(NanNew<v8::String>("session_id"), NanNew<v8::Integer>((*holder->message)->GetSessionId()));
+    sender->Set(NanNew<v8::String>("timestamp"), NanNew<v8::Integer>((*holder->message)->GetTimeStamp()));
+    sender->Set(NanNew<v8::String>("member_name"), NanNew<v8::String>((*holder->message)->GetMemberName()));
+    sender->Set(NanNew<v8::String>("object_path"), NanNew<v8::String>((*holder->message)->GetObjectPath()));
+    sender->Set(NanNew<v8::String>("signature"), NanNew<v8::String>((*holder->message)->GetSignature()));
+
     v8::Handle<v8::Value> argv[] = {
-      NanNew<v8::String>(holder->data)
+      msg,
+      sender
     };
-    holder->callback->Call(1, argv);
+    holder->callback->Call(2, argv);
+
+    if(holder->message){
+      delete holder->message;
+      holder->message = NULL;
+    }
 }
 
 void SignalHandlerImpl::Signal(const ajn::InterfaceDescription::Member *member, const char *srcPath, ajn::Message &message){
-    printf("Got Signal for %s from id %s\n", srcPath, message->GetSender());
     signal_async.data = (void*) &signalCallback;
-    //TODO message data
-    signalCallback.data = message->GetSender();
+    signalCallback.message = new ajn::Message(message);
     uv_async_send(&signal_async);
 }
-
-

--- a/src/SignalHandlerImpl.h
+++ b/src/SignalHandlerImpl.h
@@ -7,16 +7,17 @@
 #include <InterfaceDescription.h>
 #include <TransportMask.h>
 #include <alljoyn/AllJoynStd.h>
+#include <alljoyn/MessageReceiver.h>
 #include <Message.h>
 
-class SignalHandlerImpl {
+class SignalHandlerImpl : public ajn::MessageReceiver {
   private:
   	uv_loop_t *loop;
   	uv_async_t signal_async;
 
   struct CallbackHolder{
     NanCallback* callback;
-    const char* data;
+    ajn::Message* message;
   } signalCallback;
 
   public:


### PR DESCRIPTION
I have refined one features in this pull request: BusConnection::RegisterSignalHandler() supports multiple signal handlers. The original one can be called multiple times, but only the last signal handler is effective.
BTW, original SignalHandlerImpl.{cc,h} is not used, and I reused most of them in the modification.
